### PR TITLE
luacheck: disable warnings on 2ndary unused vars

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,8 +2,12 @@
 
 -- Standard globals
 std = "max+love"
+
 -- Allow defined globals
 allow_defined = true
+
+-- disable warnings about secondary unused variables
+unused_secondaries = false
 
 -- Exclude libraries: we don't really care about those
 exclude_files = {"**/lib/**"}


### PR DESCRIPTION
<!-- Some points to consider:                                               -->
<!--   * Have you updated the CHANGELOG.md for this pull request?           -->
<!--   * Check that your code follows the Style Guide located in the wiki.  -->

Changes proposed in this pull request.
- Just a minor adjustment to help reduce the warnings created by luacheck.
