### PR TITLE
fix load game crash when no save files are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The file format is based on [Keep a Change Log](https://keepachangelog.com/en/1.
 - fuel bases are now determined on demand and not up front. Big performance boost.
 - save game bug
 - fixed game over not triggering (again)
+- loading a game that doesn't exist no longer crashes the game
 
 
 ## v0.10
@@ -65,7 +66,7 @@ The file format is based on [Keep a Change Log](https://keepachangelog.com/en/1.
 - added a lovelyToast to the SAVE button
 - simple "end game" screen allows a game restart
 - low fuel audio
-- added smoke effect 
+- added smoke effect
 - an image to the main menu
 - some commentary to the code to ease understanding and maintenance
 - a CONST section (for constants) to enum.lua

--- a/source/functions.lua
+++ b/source/functions.lua
@@ -120,19 +120,38 @@ function functions.LoadGame()
 
     local savefile
     local contents
+	local size
+	local error = false
 
     savefile = savedir .. "/" .. "landers.dat"
-    contents, _ = nativefs.read( savefile)
-    garrLanders = bitser.loads(contents)
+
+	if love.filesystem.getInfo(savefile) ~= nil then
+	    contents, size = nativefs.read(savefile)
+	    garrLanders = bitser.loads(contents)
+	else
+		error = true
+	end
 
     savefile = savedir .. "/" .. "ground.dat"
-    contents, _ = nativefs.read( savefile)
-    garrGround = bitser.loads(contents)
+	if love.filesystem.getInfo(savefile) ~= nil then
+		contents, size = nativefs.read(savefile)
+	    garrGround = bitser.loads(contents)
+	else
+		error = true
+	end
 
     savefile = savedir .. "/" .. "objects.dat"
-    contents, _ = nativefs.read(savefile)
-    garrObjects = bitser.loads(contents)
+	if love.filesystem.getInfo(savefile) ~= nil then
+		contents, size = nativefs.read(savefile)
+	    garrObjects = bitser.loads(contents)
+	else
+		error = true
+	end
 
+	if error then
+		-- a file is missing, so display a popup on a new game
+		lovelyToasts.show("ERROR: Unable to load game!", 3, "middle")
+	end
 end
 
 


### PR DESCRIPTION
<!-- Some points to consider:                                               -->
<!--   * Have you updated the CHANGELOG.md for this pull request?           -->
<!--   * Check that your code follows the Style Guide located in the wiki.  -->

Fixes #222 

Changes proposed in this pull request.
- This codes checks for the game .dat files, and if they don't exist notify the user by the new world being created anyway. 

It's probably not the most elegant solution but it works :)

Happy for feedback.
